### PR TITLE
Fix dash handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "description": "Exposes a list of quality levels available for the source.",
   "main": "es5/plugin.js",
+  "jsnext:main": "src/plugin.js",
   "generator-videojs-plugin": {
     "version": "2.2.0"
   },
+  "repository": "videojs/videojs-contrib-quality-levels",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm-run-all -p build:*",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -93,7 +93,9 @@ const setupDashHandlers = function() {
   let oldBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
 
   videojs.Html5DashJS.beforeInitialize = function(player, newMediaPlayer) {
-    oldBeforeInitialize(player, newMediaPlayer);
+    if (oldBeforeInitialize) {
+      oldBeforeInitialize(player, newMediaPlayer);
+    }
 
     if (!(player.dash && player.dash.representations)) {
       return;

--- a/src/quality-level-list.js
+++ b/src/quality-level-list.js
@@ -1,5 +1,5 @@
 import videojs from 'video.js';
-import document from 'global/document';
+import { document } from 'global/document';
 
 /**
  * A list of QualityLevels.

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -96,6 +96,7 @@ QUnit.test('hls lifecyle', function(assert) {
 
 QUnit.test('dash lifecyle', function(assert) {
   let mediaPlayer = new MockMediaPlayer();
+  const oldBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
 
   this.player.dash = this.player.dash || {};
   this.player.dash.representations = () => representations;
@@ -142,4 +143,9 @@ QUnit.test('dash lifecyle', function(assert) {
 
   assert.equal(qualityLevels.selectedIndex, 2, 'set selectedIndex correctly');
   assert.equal(changeCount, 2, 'triggered change event');
+
+  this.player.trigger('dispose');
+
+  assert.strictEqual(oldBeforeInitialize, videojs.Html5DashJS.beforeInitialize,
+    'beforeInitialize properly restored on player disposal');
 });


### PR DESCRIPTION
This change uses the old `videojs.Html5DashJS.beforeInitialize` before overriding it and preoperly restores it on a player dispose so another plugin can do work before dash is initialized. Also a couple fixes so a plugin using spellbook can import this plugin.