### PR TITLE
Remove hls and dash specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,26 @@ for (let i = 0; i < qualityLevels.length; i++) {
 let currentSelectedQualityLevelIndex = qualityLevels.selectedIndex;
 ```
 
-### HLS
+### Populating the list
+Initially the list of quality levels will be empty. You can add quality levels to the list by using `QualityLevelList.addQualityLevel` for each quality level specific to your source. `QualityLevelList.addQualityLevel` takes in a `Representation` object (or generic object with the require properties). All properties except are required except `width` and `height`.
 
-Quality levels for an HLS source will be automatically populated when using [videojs-contrib-hls](https://github.com/videojs/videojs-contrib-hls).
+Example Representation
+```js
+Representation {
+  id: string,
+  width: number,
+  height: number,
+  bitrate: number,
+  enabled: function
+}
+```
 
-### Dash
+The `enabled` function should take an optional boolean to enable or disable the representation and return whether it is currently enabled.
 
-Quality levels for a Dash source will only be automatically populated when using [videojs-contrib-dash](https://github.com/videojs/videojs-contrib-dash) and if the function`player.dash.representations` exists,
-which should return a list of `Representation`s.
+#### HLS
 
-### Other
+Quality levels for an HLS source will be automatically populated when using [videojs-contrib-hls](https://github.com/videojs/videojs-contrib-hls) version 4.1 or greater.
 
-Other sources quality levels are not yet automatically populated. This can be done manually
-by using a `Representation` object for each quality level availble for your source to create
-a corresponding `QualityLevel` and add it by using `addQualityLevel`.
 
 ## Including the Plugin
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let currentSelectedQualityLevelIndex = qualityLevels.selectedIndex;
 ```
 
 ### Populating the list
-Initially the list of quality levels will be empty. You can add quality levels to the list by using `QualityLevelList.addQualityLevel` for each quality level specific to your source. `QualityLevelList.addQualityLevel` takes in a `Representation` object (or generic object with the require properties). All properties except are required except `width` and `height`.
+Initially the list of quality levels will be empty. You can add quality levels to the list by using `QualityLevelList.addQualityLevel` for each quality level specific to your source. `QualityLevelList.addQualityLevel` takes in a `Representation` object (or generic object with the required properties). All properties are required except `width` and `height`.
 
 Example Representation
 ```js

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.0",
   "description": "Exposes a list of quality levels available for the source.",
   "main": "es5/plugin.js",
+  "jsnext:main": "src/plugin.js",
   "generator-videojs-plugin": {
     "version": "2.2.0"
   },
+  "repository": "videojs/videojs-contrib-quality-levels",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm-run-all -p build:*",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -93,7 +93,9 @@ const setupDashHandlers = function() {
   let oldBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
 
   videojs.Html5DashJS.beforeInitialize = function(player, newMediaPlayer) {
-    oldBeforeInitialize(player, newMediaPlayer);
+    if (oldBeforeInitialize) {
+      oldBeforeInitialize(player, newMediaPlayer);
+    }
 
     if (!(player.dash && player.dash.representations)) {
       return;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -22,7 +22,6 @@ const initPlugin = function(player, options) {
 
   player.on('dispose', disposeHandler);
 
-  originalPluginFn = player.qualityLevels;
   player.qualityLevels = () => qualityLevelList;
   player.qualityLevels.VERSION = '__VERSION__';
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,141 +1,5 @@
 import videojs from 'video.js';
-import QualityLevel from './quality-level.js';
 import QualityLevelList from './quality-level-list.js';
-
-const noop = () => {};
-
-/**
- * Finds the index of the HLS playlist in a give list of playlists.
- *
- * @param {Object} media Playlist object to search for.
- * @param {Object[]} playlists List of playlist objects to search through.
- * @returns {number} The index of the playlist or -1 if not found.
- * @function getHlsPlaylistIndex
- */
-const getHlsPlaylistIndex = function(media, playlists) {
-  for (let i = 0; i < playlists.length; i++) {
-    let playlist = playlists[i];
-
-    if (playlist.resolvedUri === media.resolvedUri) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-/**
- * Updates the selcetedIndex of the QualityLevelList when a mediachange happens in hls.
- *
- * @param {QualityLevelList} qualityLevels The QualityLevelList to update.
- * @param {PlaylistLoader} playlistLoader PlaylistLoader containing the new media info.
- * @function handleHlsMediaChange
- */
-const handleHlsMediaChange = function(qualityLevels, playlistLoader) {
-  let newPlaylist = playlistLoader.media();
-  let selectedIndex = getHlsPlaylistIndex(newPlaylist, playlistLoader.master.playlists);
-
-  qualityLevels.selectedIndex_ = selectedIndex;
-  qualityLevels.trigger({
-    selectedIndex,
-    type: 'change'
-  });
-};
-
-/**
- * Adds quality levels to list once playlist metadata is available
- *
- * @param {QualityLevelList} qualityLevels The QualityLevelList to attach events to.
- * @param {Object} hls Hls object to listen to for media events.
- * @function handleHlsLoadedMetadata
- */
-const handleHlsLoadedMetadata = function(qualityLevels, hls) {
-  hls.representations().forEach((rep) => {
-    qualityLevels.addQualityLevel(new QualityLevel(rep));
-  });
-  handleHlsMediaChange(qualityLevels, hls.playlists);
-};
-
-/**
- * Sets up the event handlers for populating and updating the selectedIndex of the
- * QualityLevelList for an HLS source.
- *
- * @param {QualityLevelList} qualityLevels The QualityLevelList to attach events to.
- * @param {Object} hls Hls object to listen to for media events.
- * @returns {Function} Event handler cleanup function.
- * @function setupHlsHandlers
- */
-const setupHlsHandlers = function(qualityLevels, hls) {
-  const onHlsLoadedMetadata = () => {
-    handleHlsLoadedMetadata(qualityLevels, hls);
-  };
-
-  const onHlsMediaChange = () => {
-    handleHlsMediaChange(qualityLevels, hls.playlists);
-  };
-
-  hls.playlists.on('loadedmetadata', onHlsLoadedMetadata);
-  hls.playlists.on('mediachange', onHlsMediaChange);
-
-  return function() {
-    hls.playlists.off('loadedmetadata', onHlsLoadedMetadata);
-    hls.playlists.off('mediachange', onHlsMediaChange);
-  };
-};
-
-/**
- * Sets up the event handlers for populating and updating the selectedIndex of the
- * QualityLevelList for Dash source.
- *
- * @return {Function} cleanup function to restore beforeInitialize on Html5DashJS
- * @function setupDashHandlers
- */
-const setupDashHandlers = function() {
-  let oldBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
-
-  videojs.Html5DashJS.beforeInitialize = function(player, newMediaPlayer) {
-    if (oldBeforeInitialize) {
-      oldBeforeInitialize(player, newMediaPlayer);
-    }
-
-    if (!(player.dash && player.dash.representations)) {
-      return;
-    }
-
-    let qualityLevels = player.qualityLevels();
-
-    const onPlaybackMetaDataLoaded = () => {
-      let representations = player.dash.representations();
-
-      representations.forEach((rep) => {
-        qualityLevels.addQualityLevel(new QualityLevel(rep));
-      });
-    };
-
-    const onQualityChangeRequested = (event) => {
-      let selectedIndex = event.newQuality;
-
-      qualityLevels.selectedIndex_ = selectedIndex;
-      qualityLevels.trigger({
-        selectedIndex,
-        type: 'change'
-      });
-    };
-
-    const cleanup = () => {
-      newMediaPlayer.off('playbackMetaDataLoaded', onPlaybackMetaDataLoaded);
-      newMediaPlayer.off('qualityChangeRequested', onQualityChangeRequested);
-      player.off('dispose', cleanup);
-    };
-
-    newMediaPlayer.on('playbackMetaDataLoaded', onPlaybackMetaDataLoaded);
-    newMediaPlayer.on('qualityChangeRequested', onQualityChangeRequested);
-    player.on('dispose', cleanup);
-  };
-
-  return function() {
-    videojs.Html5DashJS.beforeInitialize = oldBeforeInitialize;
-  };
-};
 
 /**
  * Initialization function for the qualityLevels plugin. Sets up the QualityLevelList and
@@ -147,46 +11,15 @@ const setupDashHandlers = function() {
  */
 const initPlugin = function(player, options) {
   let originalPluginFn = player.qualityLevels;
-  let tech = player.tech({ IWillNotUseThisInPlugins: true });
-  let hls = tech.hls;
-  let cleanupHls = noop;
-  let cleanupDash = noop;
 
   const qualityLevelList = new QualityLevelList();
 
-  if (hls) {
-    cleanupHls = setupHlsHandlers(qualityLevelList, hls);
-  }
-
-  // Since Dash handlers are setup in videojs.Html5DashJS.beforeInitialize
-  // we only need to override beforeInitialize on the global videojs.Html5DashJS once
-  // instead of on every new source load.
-  if (videojs.Html5DashJS) {
-    cleanupDash = setupDashHandlers();
-  }
-
-  const loadstartHandler = function() {
-    qualityLevelList.dispose();
-    cleanupHls();
-
-    tech = player.tech({ IWillNotUseThisInPlugins: true });
-    hls = tech.hls;
-
-    if (hls) {
-      cleanupHls = setupHlsHandlers(qualityLevelList, hls);
-    }
-  };
-
   const disposeHandler = function() {
     qualityLevelList.dispose();
-    cleanupHls();
-    cleanupDash();
     player.qualityLevels = originalPluginFn;
-    player.off('loadstart', loadstartHandler);
     player.off('dispose', disposeHandler);
   };
 
-  player.on('loadstart', loadstartHandler);
   player.on('dispose', disposeHandler);
 
   originalPluginFn = player.qualityLevels;

--- a/src/quality-level-list.js
+++ b/src/quality-level-list.js
@@ -1,5 +1,5 @@
 import videojs from 'video.js';
-import document from 'global/document';
+import { document } from 'global/document';
 
 /**
  * A list of QualityLevels.

--- a/src/quality-level-list.js
+++ b/src/quality-level-list.js
@@ -71,16 +71,20 @@ class QualityLevelList extends videojs.EventTarget {
    * @param {number=}  representation.height    Resolution height of the QualityLevel
    * @param {number}   representation.bandwidth Bitrate of the QaulityLevel
    * @param {Function} representation.enabled   Callback to enable/disable QualityLevel
+   * @return {QualityLevel} the QualityLevel added to the list
    * @method addQualityLevel
    */
   addQualityLevel(representation) {
+    let qualityLevel = this.getQualityLevelById(representation.id);
+
     // Do not add duplicate quality levels
-    if (this.getQualityLevelById(representation.id)) {
-      return;
+    if (qualityLevel) {
+      return qualityLevel;
     }
 
-    const qualityLevel = new QualityLevel(representation);
     const index = this.levels_.length;
+
+    qualityLevel = new QualityLevel(representation);
 
     if (!('' + index in this)) {
       Object.defineProperty(this, index, {
@@ -96,39 +100,41 @@ class QualityLevelList extends videojs.EventTarget {
       qualityLevel,
       type: 'addqualitylevel'
     });
+
+    return qualityLevel;
   }
 
   /**
    * Removes a quality level from the list.
    *
    * @param {QualityLevel} remove QualityLevel to remove to the list.
+   * @return {QualityLevel|null} the QualityLevel removed or null if nothing removed
    * @method removeQualityLevel
    */
   removeQualityLevel(qualityLevel) {
-    let removed = false;
+    let removed = null;
 
     for (let i = 0, l = this.length; i < l; i++) {
       if (this[i] === qualityLevel) {
-        this.levels_.splice(i, 1);
+        removed = this.levels_.splice(i, 1)[0];
 
         if (this.selectedIndex_ === i) {
           this.selectedIndex_ = -1;
         } else if (this.selectedIndex_ > i) {
           this.selectedIndex_--;
         }
-        removed = true;
         break;
       }
     }
 
-    if (!removed) {
-      return;
+    if (removed) {
+      this.trigger({
+        qualityLevel,
+        type: 'removequalitylevel'
+      });
     }
 
-    this.trigger({
-      qualityLevel,
-      type: 'removequalitylevel'
-    });
+    return removed;
   }
 
   /**

--- a/src/quality-level-list.js
+++ b/src/quality-level-list.js
@@ -69,7 +69,7 @@ class QualityLevelList extends videojs.EventTarget {
    * @param {string}   representation.id        Unique id of the QualityLevel
    * @param {number=}  representation.width     Resolution width of the QualityLevel
    * @param {number=}  representation.height    Resolution height of the QualityLevel
-   * @param {number}   representation.bandwidth Bitrate of the QaulityLevel
+   * @param {number}   representation.bandwidth Bitrate of the QualityLevel
    * @param {Function} representation.enabled   Callback to enable/disable QualityLevel
    * @return {QualityLevel} the QualityLevel added to the list
    * @method addQualityLevel

--- a/src/quality-level-list.js
+++ b/src/quality-level-list.js
@@ -1,5 +1,6 @@
 import videojs from 'video.js';
 import { document } from 'global/document';
+import QualityLevel from './quality-level.js';
 
 /**
  * A list of QualityLevels.
@@ -64,16 +65,22 @@ class QualityLevelList extends videojs.EventTarget {
   /**
    * Adds a quality level to the list.
    *
-   * @param {QualityLevel} qualityLevel QualityLevel to add to the list.
+   * @param {Representation|Object} representation The representation of the quality level
+   * @param {string}   representation.id        Unique id of the QualityLevel
+   * @param {number=}  representation.width     Resolution width of the QualityLevel
+   * @param {number=}  representation.height    Resolution height of the QualityLevel
+   * @param {number}   representation.bandwidth Bitrate of the QaulityLevel
+   * @param {Function} representation.enabled   Callback to enable/disable QualityLevel
    * @method addQualityLevel
    */
-  addQualityLevel(qualityLevel) {
-    const index = this.levels_.length;
-
+  addQualityLevel(representation) {
     // Do not add duplicate quality levels
-    if (this.getQualityLevelById(qualityLevel.id)) {
+    if (this.getQualityLevelById(representation.id)) {
       return;
     }
+
+    const qualityLevel = new QualityLevel(representation);
+    const index = this.levels_.length;
 
     if (!('' + index in this)) {
       Object.defineProperty(this, index, {

--- a/src/quality-level.js
+++ b/src/quality-level.js
@@ -21,7 +21,7 @@ export default class QualityLevel {
    * @param {string}   representation.id        Unique id of the QualityLevel
    * @param {number=}  representation.width     Resolution width of the QualityLevel
    * @param {number=}  representation.height    Resolution height of the QualityLevel
-   * @param {number}   representation.bandwidth Bitrate of the QaulityLevel
+   * @param {number}   representation.bandwidth Bitrate of the QualityLevel
    * @param {Function} representation.enabled   Callback to enable/disable QualityLevel
    */
   constructor(representation) {

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,13 +1,8 @@
 import document from 'global/document';
-
 import QUnit from 'qunit';
 import sinon from 'sinon';
 import videojs from 'video.js';
-import { representations, MockPlaylistLoader, MockMediaPlayer } from './test-helpers';
-
 import plugin from '../src/plugin';
-
-videojs.Html5DashJS = videojs.Html5DashJS || {};
 
 const Player = videojs.getComponent('Player');
 
@@ -46,115 +41,4 @@ QUnit.test('registers itself with video.js', function(assert) {
     plugin,
     'videojs-contrib-quality-levels plugin was registered'
   );
-});
-
-QUnit.test('hls lifecyle', function(assert) {
-  let playlistLoader = new MockPlaylistLoader();
-
-  this.player.tech_.hls = {
-    representations() {
-      return representations;
-    },
-    playlists: playlistLoader
-  };
-
-  let qualityLevels = this.player.qualityLevels();
-  let addCount = 0;
-  let changeCount = 0;
-
-  qualityLevels.on('addqualitylevel', () => {
-    addCount++;
-  });
-
-  qualityLevels.on('change', () => {
-    changeCount++;
-  });
-
-  // Tick the clock forward enough to trigger the player to be "ready".
-  this.clock.tick(1);
-  this.player.trigger('loadstart');
-
-  assert.equal(qualityLevels.length, 0, 'no quality levels available before loadedmetadata');
-  assert.equal(qualityLevels.selectedIndex, -1, 'no quality level selected yet');
-
-  // Set mock playlist loader to select initial media to be index 0
-  playlistLoader.mediaIndex_ = 0;
-  playlistLoader.trigger('loadedmetadata');
-
-  assert.equal(qualityLevels.length, 4, 'added 4 quality levels');
-  assert.equal(addCount, 4, 'trigger 4 addqualitylevel events');
-  assert.equal(qualityLevels.selectedIndex, 0, 'set selectedIndex correctly');
-  assert.equal(changeCount, 1, 'triggered change event');
-
-  // mock abr media change
-  playlistLoader.mediaIndex_ = 2;
-  playlistLoader.trigger('mediachange');
-
-  assert.equal(qualityLevels.selectedIndex, 2, 'set selectedIndex correctly');
-  assert.equal(changeCount, 2, 'triggered change event');
-});
-
-QUnit.test('dash lifecyle', function(assert) {
-  let beforeInitCount = 0;
-  let mediaPlayer = new MockMediaPlayer();
-  const origBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
-  const expectBeforeIntitialize = function() {
-    beforeInitCount++;
-  };
-
-  videojs.Html5DashJS.beforeInitialize = expectBeforeIntitialize;
-
-  this.player.dash = this.player.dash || {};
-  this.player.dash.representations = () => representations;
-
-  let qualityLevels = this.player.qualityLevels();
-  let addCount = 0;
-  let changeCount = 0;
-
-  qualityLevels.on('addqualitylevel', () => {
-    addCount++;
-  });
-
-  qualityLevels.on('change', () => {
-    changeCount++;
-  });
-
-  // Mock before initialize being called by dash source handler
-  videojs.Html5DashJS.beforeInitialize(this.player, mediaPlayer);
-  assert.equal(beforeInitCount, 1, 'the original beforeInitialize function only called once');
-
-  assert.equal(qualityLevels.length, 0, 'no quality levels available before playbackMetaDataLoaded');
-  assert.equal(qualityLevels.selectedIndex, -1, 'no quality level selected yet');
-
-  mediaPlayer.trigger('playbackMetaDataLoaded');
-
-  assert.equal(qualityLevels.length, 4, 'added 4 quality levels');
-  assert.equal(addCount, 4, 'trigger 4 addqualitylevel events');
-  assert.equal(qualityLevels.selectedIndex, -1, 'no quality level selected yet');
-  assert.equal(changeCount, 0, 'did not trigger change event');
-
-  // Set mock media player to select initial media to be index 0
-  mediaPlayer.trigger({
-    type: 'qualityChangeRequested',
-    newQuality: 0
-  });
-
-  assert.equal(qualityLevels.selectedIndex, 0, 'set selectedIndex correctly');
-  assert.equal(changeCount, 1, 'triggered change event');
-
-  // mock abr media change
-  mediaPlayer.trigger({
-    type: 'qualityChangeRequested',
-    newQuality: 2
-  });
-
-  assert.equal(qualityLevels.selectedIndex, 2, 'set selectedIndex correctly');
-  assert.equal(changeCount, 2, 'triggered change event');
-
-  this.player.trigger('dispose');
-
-  assert.strictEqual(expectBeforeIntitialize, videojs.Html5DashJS.beforeInitialize,
-    'beforeInitialize properly restored on player disposal');
-
-  videojs.Html5DashJS.beforeInitialize = origBeforeInitialize;
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -95,8 +95,14 @@ QUnit.test('hls lifecyle', function(assert) {
 });
 
 QUnit.test('dash lifecyle', function(assert) {
+  let beforeInitCount = 0;
   let mediaPlayer = new MockMediaPlayer();
-  const oldBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
+  const origBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
+  const expectBeforeIntitialize = function() {
+    beforeInitCount++;
+  };
+
+  videojs.Html5DashJS.beforeInitialize = expectBeforeIntitialize;
 
   this.player.dash = this.player.dash || {};
   this.player.dash.representations = () => representations;
@@ -115,6 +121,7 @@ QUnit.test('dash lifecyle', function(assert) {
 
   // Mock before initialize being called by dash source handler
   videojs.Html5DashJS.beforeInitialize(this.player, mediaPlayer);
+  assert.equal(beforeInitCount, 1, 'the original beforeInitialize function only called once');
 
   assert.equal(qualityLevels.length, 0, 'no quality levels available before playbackMetaDataLoaded');
   assert.equal(qualityLevels.selectedIndex, -1, 'no quality level selected yet');
@@ -146,6 +153,8 @@ QUnit.test('dash lifecyle', function(assert) {
 
   this.player.trigger('dispose');
 
-  assert.strictEqual(oldBeforeInitialize, videojs.Html5DashJS.beforeInitialize,
+  assert.strictEqual(expectBeforeIntitialize, videojs.Html5DashJS.beforeInitialize,
     'beforeInitialize properly restored on player disposal');
+
+  videojs.Html5DashJS.beforeInitialize = origBeforeInitialize;
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -96,6 +96,7 @@ QUnit.test('hls lifecyle', function(assert) {
 
 QUnit.test('dash lifecyle', function(assert) {
   let mediaPlayer = new MockMediaPlayer();
+  const oldBeforeInitialize = videojs.Html5DashJS.beforeInitialize;
 
   this.player.dash = this.player.dash || {};
   this.player.dash.representations = () => representations;
@@ -142,4 +143,9 @@ QUnit.test('dash lifecyle', function(assert) {
 
   assert.equal(qualityLevels.selectedIndex, 2, 'set selectedIndex correctly');
   assert.equal(changeCount, 2, 'triggered change event');
+
+  this.player.trigger('dispose');
+
+  assert.strictEqual(oldBeforeInitialize, videojs.Html5DashJS.beforeInitialize,
+    'beforeInitialize properly restored on player disposal');
 });

--- a/test/quality-level-list.test.js
+++ b/test/quality-level-list.test.js
@@ -28,13 +28,13 @@ QUnit.test('Properly adds QualityLevels to the QualityLevelList', function(asser
   assert.equal(addCount, 2, 'emmitted addqualitylevel event');
   assert.strictEqual(this.qualityLevels[1], expected1, 'can access quality level with index');
 
-  let expected3 = this.qualityLevels.addQualityLevel(this.levels[0]);
+  let expectedDuplicate = this.qualityLevels.addQualityLevel(this.levels[0]);
 
   assert.equal(this.qualityLevels.length, 2, 'does not add duplicate quality level');
   assert.equal(addCount, 2, 'no event emitted on dulicate');
   assert.strictEqual(this.qualityLevels[3], undefined, 'no index property defined');
   assert.strictEqual(this.qualityLevels[0], expected0, 'quality level unchanged');
-  assert.strictEqual(this.qualityLevels[0], expected3, 'adding duplicate returns same reference');
+  assert.strictEqual(this.qualityLevels[0], expectedDuplicate, 'adding duplicate returns same reference');
   assert.strictEqual(this.qualityLevels[1], expected1, 'quality level unchanged');
 });
 
@@ -55,34 +55,34 @@ QUnit.test('Properly removes QualityLevels from the QualityLevelList', function(
 
   assert.equal(this.qualityLevels.length, 4, '4 initial quality levels');
 
-  let removed0 = this.qualityLevels.removeQualityLevel(expected[3]);
+  let removed = this.qualityLevels.removeQualityLevel(expected[3]);
 
   assert.equal(this.qualityLevels.length, 3, 'removed quality level');
   assert.equal(removeCount, 1, 'emitted removequalitylevel event');
-  assert.strictEqual(removed0, expected[3], 'returned removed level');
+  assert.strictEqual(removed, expected[3], 'returned removed level');
   assert.notStrictEqual(this.qualityLevels[3], expected[3], 'nothing at index');
 
-  let removed1 = this.qualityLevels.removeQualityLevel(expected[1]);
+  removed = this.qualityLevels.removeQualityLevel(expected[1]);
 
   assert.equal(this.qualityLevels.length, 2, 'removed quality level');
   assert.equal(removeCount, 2, 'emitted removequalitylevel event');
-  assert.strictEqual(removed1, expected[1], 'returned removed level');
+  assert.strictEqual(removed, expected[1], 'returned removed level');
   assert.notStrictEqual(this.qualityLevels[1], expected[1], 'quality level not at index');
   assert.strictEqual(this.qualityLevels[this.qualityLevels.selectedIndex],
                      expected[2],
                      'selected index properly adjusted on quality level removal');
 
-  let removed2 = this.qualityLevels.removeQualityLevel(expected[3]);
+  removed = this.qualityLevels.removeQualityLevel(expected[3]);
 
   assert.equal(this.qualityLevels.length, 2, 'no quality level removed if not found');
-  assert.equal(removed2, null, 'returned null when nothing removed');
+  assert.equal(removed, null, 'returned null when nothing removed');
   assert.equal(removeCount, 2, 'no event emitted when quality level not found');
 
-  let removed3 = this.qualityLevels.removeQualityLevel(expected[2]);
+  removed = this.qualityLevels.removeQualityLevel(expected[2]);
 
   assert.equal(this.qualityLevels.length, 1, 'quality level removed');
   assert.equal(removeCount, 3, 'emitted removequalitylevel event');
-  assert.strictEqual(removed3, expected[2], 'returned removed level');
+  assert.strictEqual(removed, expected[2], 'returned removed level');
   assert.equal(this.qualityLevels.selectedIndex, -1, 'selectedIndex set to -1 when removing selected quality level');
 });
 

--- a/test/quality-level-list.test.js
+++ b/test/quality-level-list.test.js
@@ -5,7 +5,7 @@ import { representations } from './test-helpers';
 QUnit.module('QualityLevelList', {
   beforeEach() {
     this.qualityLevels = new QualityLevelList();
-    this.levels = Array.from(representations);
+    this.levels = representations;
   }
 });
 

--- a/test/quality-level-list.test.js
+++ b/test/quality-level-list.test.js
@@ -1,12 +1,11 @@
 import QUnit from 'qunit';
 import QualityLevelList from '../src/quality-level-list';
-import QualityLevel from '../src/quality-level';
 import { representations } from './test-helpers';
 
 QUnit.module('QualityLevelList', {
   beforeEach() {
     this.qualityLevels = new QualityLevelList();
-    this.levels = representations.map((rep) => new QualityLevel(rep));
+    this.levels = Array.from(representations);
   }
 });
 
@@ -17,32 +16,34 @@ QUnit.test('Properly adds QualityLevels to the QualityLevelList', function(asser
     addCount++;
   });
 
-  this.qualityLevels.addQualityLevel(this.levels[0]);
+  let expected0 = this.qualityLevels.addQualityLevel(this.levels[0]);
 
   assert.equal(this.qualityLevels.length, 1, 'added quality level');
   assert.equal(addCount, 1, 'emmitted addqualitylevel event');
-  assert.strictEqual(this.qualityLevels[0], this.levels[0], 'can access quality level with index');
+  assert.strictEqual(this.qualityLevels[0], expected0, 'can access quality level with index');
 
-  this.qualityLevels.addQualityLevel(this.levels[1]);
+  let expected1 = this.qualityLevels.addQualityLevel(this.levels[1]);
 
   assert.equal(this.qualityLevels.length, 2, 'added quality level');
   assert.equal(addCount, 2, 'emmitted addqualitylevel event');
-  assert.strictEqual(this.qualityLevels[1], this.levels[1], 'can access quality level with index');
+  assert.strictEqual(this.qualityLevels[1], expected1, 'can access quality level with index');
 
-  this.qualityLevels.addQualityLevel(this.levels[0]);
+  let expected3 = this.qualityLevels.addQualityLevel(this.levels[0]);
 
   assert.equal(this.qualityLevels.length, 2, 'does not add duplicate quality level');
   assert.equal(addCount, 2, 'no event emitted on dulicate');
   assert.strictEqual(this.qualityLevels[3], undefined, 'no index property defined');
-  assert.strictEqual(this.qualityLevels[0], this.levels[0], 'quality level unchanged');
-  assert.strictEqual(this.qualityLevels[1], this.levels[1], 'quality level unchanged');
+  assert.strictEqual(this.qualityLevels[0], expected0, 'quality level unchanged');
+  assert.strictEqual(this.qualityLevels[0], expected3, 'adding duplicate returns same reference');
+  assert.strictEqual(this.qualityLevels[1], expected1, 'quality level unchanged');
 });
 
 QUnit.test('Properly removes QualityLevels from the QualityLevelList', function(assert) {
   let removeCount = 0;
+  const expected = [];
 
   this.levels.forEach((qualityLevel) => {
-    this.qualityLevels.addQualityLevel(qualityLevel);
+    expected.push(this.qualityLevels.addQualityLevel(qualityLevel));
   });
 
   this.qualityLevels.on('removequalitylevel', (event) => {
@@ -54,49 +55,55 @@ QUnit.test('Properly removes QualityLevels from the QualityLevelList', function(
 
   assert.equal(this.qualityLevels.length, 4, '4 initial quality levels');
 
-  this.qualityLevels.removeQualityLevel(this.levels[3]);
+  let removed0 = this.qualityLevels.removeQualityLevel(expected[3]);
 
   assert.equal(this.qualityLevels.length, 3, 'removed quality level');
   assert.equal(removeCount, 1, 'emitted removequalitylevel event');
-  assert.notStrictEqual(this.qualityLevels[3], this.levels[3], 'nothing at index');
+  assert.strictEqual(removed0, expected[3], 'returned removed level');
+  assert.notStrictEqual(this.qualityLevels[3], expected[3], 'nothing at index');
 
-  this.qualityLevels.removeQualityLevel(this.levels[1]);
+  let removed1 = this.qualityLevels.removeQualityLevel(expected[1]);
 
   assert.equal(this.qualityLevels.length, 2, 'removed quality level');
   assert.equal(removeCount, 2, 'emitted removequalitylevel event');
-  assert.notStrictEqual(this.qualityLevels[1], this.levels[1], 'quality level not at index');
+  assert.strictEqual(removed1, expected[1], 'returned removed level');
+  assert.notStrictEqual(this.qualityLevels[1], expected[1], 'quality level not at index');
   assert.strictEqual(this.qualityLevels[this.qualityLevels.selectedIndex],
-                     this.levels[2],
+                     expected[2],
                      'selected index properly adjusted on quality level removal');
 
-  this.qualityLevels.removeQualityLevel(this.levels[3]);
+  let removed2 = this.qualityLevels.removeQualityLevel(expected[3]);
 
   assert.equal(this.qualityLevels.length, 2, 'no quality level removed if not found');
+  assert.equal(removed2, null, 'returned null when nothing removed');
   assert.equal(removeCount, 2, 'no event emitted when quality level not found');
 
-  this.qualityLevels.removeQualityLevel(this.levels[2]);
+  let removed3 = this.qualityLevels.removeQualityLevel(expected[2]);
 
   assert.equal(this.qualityLevels.length, 1, 'quality level removed');
   assert.equal(removeCount, 3, 'emitted removequalitylevel event');
+  assert.strictEqual(removed3, expected[2], 'returned removed level');
   assert.equal(this.qualityLevels.selectedIndex, -1, 'selectedIndex set to -1 when removing selected quality level');
 });
 
 QUnit.test('can get quality level by id', function(assert) {
+  const expected = [];
+
   this.levels.forEach((qualityLevel) => {
-    this.qualityLevels.addQualityLevel(qualityLevel);
+    expected.push(this.qualityLevels.addQualityLevel(qualityLevel));
   });
 
   assert.strictEqual(this.qualityLevels.getQualityLevelById('0'),
-                     this.levels[0],
+                     expected[0],
                      'found quality level with id "0"');
   assert.strictEqual(this.qualityLevels.getQualityLevelById('1'),
-                     this.levels[1],
+                     expected[1],
                      'found quality level with id "1"');
   assert.strictEqual(this.qualityLevels.getQualityLevelById('2'),
-                     this.levels[2],
+                     expected[2],
                      'found quality level with id "2"');
   assert.strictEqual(this.qualityLevels.getQualityLevelById('3'),
-                     this.levels[3],
+                     expected[3],
                      'found quality level with id "3"');
   assert.strictEqual(this.qualityLevels.getQualityLevelById('4'),
                      null,

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -1,5 +1,3 @@
-import videojs from 'video.js';
-
 export const representations = [
   {
     id: '0',
@@ -38,37 +36,3 @@ export const representations = [
     }
   }
 ];
-
-export class MockPlaylistLoader extends videojs.EventTarget {
-  constructor() {
-    super();
-    this.master = {
-      playlists: [
-        {
-          resolvedUri: '0.m3u8'
-        },
-        {
-          resolvedUri: '1.m3u8'
-        },
-        {
-          resolvedUri: '2.m3u8'
-        },
-        {
-          resolvedUri: '3.m3u8'
-        }
-      ]
-    };
-
-    this.mediaIndex_ = -1;
-  }
-
-  media() {
-    return this.master.playlists[this.mediaIndex_];
-  }
-}
-
-export class MockMediaPlayer extends videojs.EventTarget {
-  constructor() {
-    super();
-  }
-}


### PR DESCRIPTION
This removes hls and dash specific quality list population from this project in favor of letting users of this project control the implementation of list population. 

The automatic hls population described in the README requires this [PR](https://github.com/videojs/videojs-contrib-hls/pull/888) in videojs-contrib-hls. `package.json` and `index.html` will also have to be updated once said pr is merged into videojs-contrib-hls to reflect the changes in the demo page.