### PR TITLE
add changerendered to list of allowed events

### DIFF
--- a/src/quality-level-list.js
+++ b/src/quality-level-list.js
@@ -173,11 +173,14 @@ class QualityLevelList extends videojs.EventTarget {
 
 /**
  * change - The selected QualityLevel has changed.
+ * changerendered - Should be triggered once the selected level referenced by the most
+ *  recent change event is rendered on screen.
  * addqualitylevel - A QualityLevel has been added to the QualityLevelList.
  * removequalitylevel - A QualityLevel has been removed from the QualityLevelList.
  */
 QualityLevelList.prototype.allowedEvents_ = {
   change: 'change',
+  changerendered: 'changerendered',
   addqualitylevel: 'addqualitylevel',
   removequalitylevel: 'removequalitylevel'
 };


### PR DESCRIPTION
I'm proposing the addition of a `changerendered` event to the list of allowed events on the `QualityLevelList`. Like the `change` event, this plugin alone will not trigger `changerendered` events. That will be the job of whoever is populating the list (e.g. videojs-contrib-hls). I think that it would be useful to know both when a change in the loading quality happens and when that change is reflected to the viewer.