### PR TITLE
fix: report correct version

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,6 @@
 import videojs from 'video.js';
 import QualityLevelList from './quality-level-list.js';
+import {version as VERSION} from '../package.json';
 
 // vjs 5/6 support
 const registerPlugin = videojs.registerPlugin || videojs.plugin;
@@ -50,6 +51,6 @@ const qualityLevels = function(options) {
 registerPlugin('qualityLevels', qualityLevels);
 
 // Include the version number.
-qualityLevels.VERSION = '__VERSION__';
+qualityLevels.VERSION = VERSION;
 
 export default qualityLevels;


### PR DESCRIPTION
A few generator versions ago we used to find-replace `__VERSION__` with the package version, but we no longer do that.