### PR TITLE
feat: add frameRate property to the quality level

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Maintenance Status: Stable
 
 
 - [Installation](#installation)
+- [Installation](#installation-1)
 - [Using](#using)
 - [Supporting Quality Levels for your source](#supporting-quality-levels-for-your-source)
   - [Populating the list](#populating-the-list)
@@ -111,7 +112,7 @@ This project provides the framework for working with source quality levels. Just
 If you are not using one of the supported projects, but still want to use quality levels with your source, you will have to implement your own plugin that populates the list and triggers change events when selected level changes. Implementing such a plugin is very specific to the source in question, so it is difficult to provide specific examples, but will most likely require a custom middleware, source handler, or tech.
 
 ### Populating the list
-Initially the list of quality levels will be empty. You can add quality levels to the list by using `QualityLevelList.addQualityLevel` for each quality level specific to your source. `QualityLevelList.addQualityLevel` takes in a `Representation` object (or generic object with the required properties). All properties are required except `width` and `height`.
+Initially the list of quality levels will be empty. You can add quality levels to the list by using `QualityLevelList.addQualityLevel` for each quality level specific to your source. `QualityLevelList.addQualityLevel` takes in a `Representation` object (or generic object with the required properties). All properties are required except `width`, `height` and `frameRate`.
 
 Example Representation
 ```js
@@ -120,6 +121,7 @@ Representation {
   width: number,
   height: number,
   bitrate: number,
+  frameRate: number,
   enabled: function
 }
 ```

--- a/src/quality-level-list.js
+++ b/src/quality-level-list.js
@@ -65,6 +65,7 @@ class QualityLevelList extends videojs.EventTarget {
    * @param {number=}  representation.width     Resolution width of the QualityLevel
    * @param {number=}  representation.height    Resolution height of the QualityLevel
    * @param {number}   representation.bandwidth Bitrate of the QualityLevel
+   * @param {number=}  representation.frameRate Frame-rate of the QualityLevel
    * @param {Function} representation.enabled   Callback to enable/disable QualityLevel
    * @return {QualityLevel} the QualityLevel added to the list
    * @method addQualityLevel

--- a/src/quality-level.js
+++ b/src/quality-level.js
@@ -22,6 +22,7 @@ export default class QualityLevel {
    * @param {number=}  representation.width     Resolution width of the QualityLevel
    * @param {number=}  representation.height    Resolution height of the QualityLevel
    * @param {number}   representation.bandwidth Bitrate of the QualityLevel
+   * @param {number=}  representation.frameRate Frame-rate of the QualityLevel
    * @param {Function} representation.enabled   Callback to enable/disable QualityLevel
    */
   constructor(representation) {
@@ -33,6 +34,7 @@ export default class QualityLevel {
     level.width = representation.width;
     level.height = representation.height;
     level.bitrate = representation.bandwidth;
+    level.frameRate = representation.frameRate;
     level.enabled_ = representation.enabled;
 
     Object.defineProperty(level, 'enabled', {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -4,6 +4,7 @@ export const representations = [
     width: 100,
     height: 100,
     bandwidth: 100,
+    frameRate: 29.956,
     enabled() {
       return true;
     }
@@ -13,6 +14,7 @@ export const representations = [
     width: 200,
     height: 200,
     bandwidth: 200,
+    frameRate: 29.956,
     enabled() {
       return true;
     }
@@ -22,6 +24,7 @@ export const representations = [
     width: 300,
     height: 300,
     bandwidth: 300,
+    frameRate: 30,
     enabled() {
       return true;
     }
@@ -31,6 +34,7 @@ export const representations = [
     width: 400,
     height: 400,
     bandwidth: 400,
+    frameRate: 60,
     enabled() {
       return true;
     }


### PR DESCRIPTION
## Description
I would like to display to the user the frame rate value for the currently playing quality level. However, it is not possible because the Representation class doesn't have the frameRate property.
This PR is related to this https://github.com/videojs/http-streaming/pull/1289

## Specific Changes proposed
Add frameRate property to the quality level.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [X] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
