### PR TITLE
chore(package): add Video.js 8 as a compatible version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
   ],
   "dependencies": {
     "global": "^4.3.2",
-    "video.js": "^6 || ^7"
+    "video.js": "^6 || ^7 || ^8"
   },
   "peerDependencies": {
-    "video.js": "^6 || ^7"
+    "video.js": "^6 || ^7 || ^8"
   },
   "devDependencies": {
     "conventional-changelog-cli": "^2.0.1",


### PR DESCRIPTION
## Description
With Video.js 8 coming, this ensures that it is listed as compatible.

## Specific Changes proposed
Add ` || ^8` to the `package.json` `dependencies`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
