### PR TITLE
chore: do not run tests on npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "pretest": "npm-run-all lint build",
     "test": "karma start scripts/karma.conf.js",
     "update-changelog": "conventional-changelog -p videojs -i CHANGELOG.md -s",
-    "preversion": "npm test",
     "version": "is-prerelease || npm run update-changelog && git add CHANGELOG.md",
     "watch": "npm-run-all -p watch:*",
     "watch:js": "npm run build:js -- -w",


### PR DESCRIPTION
## Description
We have stopped running `npm test` as a `preversion` script. Looks like this repo was missed!

## Specific Changes proposed
Remove the `preversion` script.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
