### PR TITLE
chore: fix package.json import for webpack5 compatibility

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,6 +1,6 @@
 import videojs from 'video.js';
 import QualityLevelList from './quality-level-list.js';
-import {version as VERSION} from '../package.json';
+import packageInfo from '../package.json';
 
 /**
  * Initialization function for the qualityLevels plugin. Sets up the QualityLevelList and
@@ -24,7 +24,7 @@ const initPlugin = function(player, options) {
   player.on('dispose', disposeHandler);
 
   player.qualityLevels = () => qualityLevelList;
-  player.qualityLevels.VERSION = VERSION;
+  player.qualityLevels.VERSION = packageInfo.version;
 
   return qualityLevelList;
 };
@@ -48,6 +48,6 @@ const qualityLevels = function(options) {
 videojs.registerPlugin('qualityLevels', qualityLevels);
 
 // Include the version number.
-qualityLevels.VERSION = VERSION;
+qualityLevels.VERSION = packageInfo.version;
 
 export default qualityLevels;


### PR DESCRIPTION
## Description
When using Webpack 5 this warning is thrown during builds:
```
videojs-contrib-quality-levels/src/plugin.js @ 30:33-40
Should not import the named export 'version' (imported as 'VERSION') from default-exporting module (only default export is available soon)
```

This updates importing `package.json` and updates the `version` references in plugin.js.  

## Specific Changes proposed
* Import `package.json` as full object named `packageInfo` and reference accordingly

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
